### PR TITLE
Helm charts releases Envoy and DNSMasqAks

### DIFF
--- a/.github/workflows/Release-dnsmasq.yml
+++ b/.github/workflows/Release-dnsmasq.yml
@@ -1,0 +1,36 @@
+name: Main - Release Helm Chart DNSMasq
+on: 
+  push:
+    branches: 
+      - main
+    paths:
+      # Only run this when chart file is updated.
+      - 'deployment/helm/dnsmasqaks/Chart.yaml'
+      
+jobs:
+  Release-Artifacts:      
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Get the version
+      id: vars
+      run: echo ::set-output name=tag::$(echo main-${GITHUB_SHA})
+      
+    - name: Echo Docker images tag
+      run: echo ${{steps.vars.outputs.tag}}
+
+    - name: Run chart-releaser
+      uses: helm/chart-releaser-action@v1.1.0
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      with:
+        charts_dir: deployment/helm

--- a/.github/workflows/Release-envoy-proxy.yml
+++ b/.github/workflows/Release-envoy-proxy.yml
@@ -1,0 +1,36 @@
+name: Main - Release Helm Chart Envoy Proxy
+on: 
+  push:
+    branches: 
+      - main
+    paths:
+      # Only run this when chart file is updated.
+      - 'deployment/helm/envoy/Chart.yaml'
+      
+jobs:
+  Release-Artifacts:      
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Get the version
+      id: vars
+      run: echo ::set-output name=tag::$(echo main-${GITHUB_SHA})
+      
+    - name: Echo Docker images tag
+      run: echo ${{steps.vars.outputs.tag}}
+
+    - name: Run chart-releaser
+      uses: helm/chart-releaser-action@v1.1.0
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      with:
+        charts_dir: deployment/helm

--- a/deployment/helm/dnsmasqaks/.helmignore
+++ b/deployment/helm/dnsmasqaks/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+.tgz
+index.yaml

--- a/deployment/helm/dnsmasqaks/Chart.yaml
+++ b/deployment/helm/dnsmasqaks/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: dnsmasq
+description: A Helm chart for deploying DNSmasq on Kubernetes as a DNS custom server.
+keywords:
+    - dns
+    - dnsmasq
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.1.0

--- a/deployment/helm/dnsmasqaks/templates/dnsmasq/configmaps.yaml
+++ b/deployment/helm/dnsmasqaks/templates/dnsmasq/configmaps.yaml
@@ -1,0 +1,28 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dnsmasq-conf
+  labels:
+    app: dnsmasq
+data:
+  dnsmasq.conf: |
+    {{- $dnsServer := .Values.proxyDnsServer -}}
+    {{- range $key, $val := .Values.wildcardDomains }}
+    address=/{{- $val -}}/{{- $dnsServer }}
+    {{- end }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dnsmasq-hosts
+  labels:
+    app: dnsmasq
+data:
+  hosts: |
+    {{- $dnsServer := .Values.proxyDnsServer -}}
+    {{- range $key, $val := .Values.hostsDomains }}
+    {{ $dnsServer }} {{ $val }}
+    {{- end }}
+  

--- a/deployment/helm/dnsmasqaks/templates/dnsmasq/deployment.yaml
+++ b/deployment/helm/dnsmasqaks/templates/dnsmasq/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dnsmasq-module-deployment
+spec:
+  selector:
+    matchLabels:
+      app: dnsmasq
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: dnsmasq
+    spec:
+      containers: 
+      - image: {{ .Values.image }}
+        name: dnsmasq 
+        ports: 
+        - containerPort: 53 
+          protocol: UDP 
+          name: udp-53
+        volumeMounts: 
+        - name: dnsmasq-conf 
+          mountPath: "/var/dnsmasq/conf" 
+        - name: dnsmasq-hosts 
+          mountPath: "/var/dnsmasq"
+        securityContext: 
+          capabilities: 
+            add: 
+            - NET_ADMIN 
+      dnsPolicy: None 
+      dnsConfig: 
+        nameservers: 
+        - {{ .Values.azureDnsServer }}
+      restartPolicy: Always 
+      volumes: 
+      - name: dnsmasq-conf 
+        configMap: 
+          defaultMode: 0666 
+          name:  dnsmasq-conf 
+      - name: dnsmasq-hosts 
+        configMap: 
+          defaultMode: 0666 
+          name:  dnsmasq-hosts 

--- a/deployment/helm/dnsmasqaks/templates/dnsmasq/service.yaml
+++ b/deployment/helm/dnsmasqaks/templates/dnsmasq/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dsnmasq-service
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    app: dnsmasq
+  ports:
+    - protocol: UDP
+      port: 53
+      targetPort: 53

--- a/deployment/helm/dnsmasqaks/values.yaml
+++ b/deployment/helm/dnsmasqaks/values.yaml
@@ -1,0 +1,39 @@
+image: ghcr.io/azure-samples/distributed-az-iot-edge/dnsmasqaks:main-41d901d
+
+proxyDnsServer: to_replace
+azureDnsServer: "168.63.129.16" # Azure DNS
+
+hostsDomains:
+  management_azure_com: management.azure.com # for AKS egress
+  mcr_microsoft_com: mcr.microsoft.com # for AKS egress
+  login_microsoftonline_com: login.microsoftonline.com # for AKS egress
+  package_ms_com: packages.microsoft.com # for AKS egress
+  acs_mirror_azureedge_net: acs-mirror.azureedge.net # for AKS egress
+  gbl_his_arc_azure_com: gbl.his.arc.azure.com # Arc
+  k8connecthelm_azureedge_net: k8connecthelm.azureedge.net # Arc
+  sts_windows_net: sts.windows.net # Arc
+  k8sconnectcsp_azureedge_net: k8sconnectcsp.azureedge.net # Arc
+  azure_samples_github: azure-samples.github.io # TODO remove once usage of connected container registry
+  github_com: github.com # for base resources/helm/containers # TODO remove once usage of connected container registry
+  ghcr_io: ghcr.io # for base resources/helm/containers # TODO remove once usage of connected container registry
+  dapr_github_io: dapr.github.io # for dapr helm charts # TODO remove once usage of connected container registry
+
+wildcardDomains:
+  his_arc_azure_com: "his.arc.azure.com"
+  arc_azure_net: "arc.azure.net"
+  obo_arc_azure_com: "obo.arc.azure.com"
+  data_mcr_microsoft_com: "data.mcr.microsoft.com"
+  guestconfiguration_azure_com: "guestconfiguration.azure.com" # Arc
+  region_login_ms_com: "login.microsoft.com" # Arc
+  region_dp_kubernetesconfiguration_az_com: "dp.kubernetesconfiguration.azure.com" #Arc
+  guestnotificationservice_azure_com: "guestnotificationservice.azure.com" # Arc
+  servicebus_windows_net: "servicebus.windows.net" # Arc
+  hcp_region_azmk8s.io: "azmk8s.io"  # for AKS egress
+  docker_com: "docker.com" # temporary for mosquitto image # TODO remove once usage of connected container registry
+  docker_io: "docker.io" # temporary for mosquitto image # TODO remove once usage of connected container registry
+  azurecr_io: "azurecr.io" # temporary for dev images of this project # TODO remove once usage of connected container registry
+  githubusercontent_com: "githubusercontent.com" # for flux repo in GitHub
+
+# Provide additional domains that you want to proxy through, pass the whole collection through Values
+# customDomains:
+#   domain1: www.domain1.com

--- a/deployment/helm/envoy/.helmignore
+++ b/deployment/helm/envoy/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+.tgz
+index.yaml

--- a/deployment/helm/envoy/Chart.yaml
+++ b/deployment/helm/envoy/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: envoy-reverseproxy
+description: A Helm chart for deploying Envoy Reverse Proxy on K8s.
+keywords:
+    - envoy
+    - reverse proxy
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.1.0

--- a/deployment/helm/envoy/templates/NOTES.txt
+++ b/deployment/helm/envoy/templates/NOTES.txt
@@ -1,0 +1,6 @@
+You have installed release {{ .Chart.Version}} of {{ .Chart.Name }} of envoy proxy, pre-release version.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/deployment/helm/envoy/templates/envoy/envoy.yaml
+++ b/deployment/helm/envoy/templates/envoy/envoy.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy-module-deployment
+spec:
+  selector:
+    matchLabels:
+      app: envoy-module
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: envoy-module
+    spec:
+      volumes:
+        - name: envoy-volume
+          configMap:
+            name: envoy-configmap
+      containers:
+      - name: envoy-module
+        image: envoyproxy/envoy:v1.25-latest
+        imagePullPolicy: IfNotPresent
+        command: 
+{{ toYaml .Values.command | indent 12 }}
+        args:
+{{ toYaml .Values.args | indent 12 }}
+        volumeMounts:
+        - name: envoy-volume
+          mountPath: /etc/envoy/envoy.yaml
+          subPath: envoy.yaml
+        ports:
+        - containerPort: {{ .Values.envoyReverseProxy.httpsContainerPort }}
+          name: https
+          protocol: TCP
+        - containerPort: 50001
+          name: wildcard
+        - containerPort: {{ .Values.envoyReverseProxy.oboPort }} # Azure Arc requirement for cluster connect
+          name: obo
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 9901
+          initialDelaySeconds: 5
+          periodSeconds: 15
+        readinessProbe:
+          tcpSocket:
+            port: 9901
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      # setting hostNetwork true trigger DNS injection default Azure based DNS as opposed to Kube-DNS one 
+      # which is what we want for Level 4 going out to internet through pod proxy but resolving locally elsewhere in cluster
+      {{- if not .Values.parent.enabled }}
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- end }}

--- a/deployment/helm/envoy/templates/envoy/envoyconfigmap.yaml
+++ b/deployment/helm/envoy/templates/envoy/envoyconfigmap.yaml
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-configmap
+data:
+  envoy.yaml: |-
+    admin:
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+    static_resources:
+      listeners:
+      - name: https_listener
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 50000
+        
+        listener_filters:
+        - name: envoy.filters.listener.tls_inspector
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+        per_connection_buffer_limit_bytes: 32768  # 32 KiB
+        filter_chains:
+        {{- $domainRegion := .Values.domainRegion -}}
+        {{- if .Values.parent.enabled }}
+        - filter_chain_match:
+            server_names:
+              {{- range $key, $val := .Values.arcDomainNames }}
+              - {{ $val }}
+              {{- end }}
+              {{- range $key, $val := .Values.arcRegionalDomains }}
+              - {{ $domainRegion -}} {{ $val }}
+              {{- end }}
+              {{- range $key, $val := .Values.customDomains }}
+              - {{ $val }}
+              {{- end }}
+              {{- range $key, $val := .Values.arcWildcardSubDomains }}
+              - {{ $val | quote }}
+              {{- end }}
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: parent-passthrough
+                stat_prefix: parent_passthr
+        {{- else }}
+        {{- range $key, $val := .Values.arcDomainNames }}
+        - filter_chain_match:
+            server_names:
+              - {{ $val }}
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: {{ $key }}
+                stat_prefix: {{ $key }}_tcp
+        {{- end }}
+        {{- range $key, $val := .Values.arcRegionalDomains }}
+        - filter_chain_match:
+            server_names:
+              - {{ $domainRegion -}} {{ $val }}
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: {{ $key }}
+                stat_prefix: {{ $key }}_tcp
+        {{- end }}
+        {{- range $key, $val := .Values.customDomains }}
+        - filter_chain_match:
+            server_names:
+              - {{ $val }}
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: {{ $key }}
+                stat_prefix: {{ $key }}_tcp
+        {{- end }}
+        {{- if .Values.arcWildcardSubDomains}}
+        # Temporary solution for wildcard subdomains, using SNI foward proxy which is not production ready
+        # Must be the last filter chain in the list to match wildcard domains that have not been matched above
+        # Example gbl.his.arc.azure.com is matched above, all other *.his.arc.azure.com will be matched here
+        - filter_chain_match:
+            server_names:
+              {{- range $key, $val := .Values.arcWildcardSubDomains }}
+              - {{ $val | quote }}
+              {{- end }} 
+          filters:
+            - name: envoy.filters.network.sni_dynamic_forward_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3.FilterConfig
+                port_value: {{ .Values.parent.proxyHttpsPort }}
+                dns_cache_config:
+                  name: dynamic_forward_proxy_cache_config
+                  dns_lookup_family: V4_ONLY
+            - name: envoy.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                stat_prefix: forward_wildcard_tcp
+                cluster: dynamic_forward_proxy_cluster
+        {{- end }}
+        {{- end }} 
+
+      - name: obo_listener
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: {{ .Values.envoyReverseProxy.oboPort }}
+        
+        listener_filters:
+        - name: envoy.filters.listener.tls_inspector
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+        per_connection_buffer_limit_bytes: 32768  # 32 KiB
+        filter_chains:
+        {{- $domainRegion := .Values.domainRegion -}}
+        {{- if .Values.parent.enabled }}
+        - filter_chain_match:
+            server_names:
+              - {{ $domainRegion -}} {{ .Values.arcOboClusterConnect.region_obo_arc_azure_com }}
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: parent-passthrough-obo
+                stat_prefix: parent_passthr_obo
+        {{- else }}
+        
+        - filter_chain_match:
+            server_names:
+              - {{ $domainRegion -}} {{ .Values.arcOboClusterConnect.region_obo_arc_azure_com }}
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: region-obo-arc-azure-com
+                stat_prefix: obo_tcp
+        {{- end }}
+      
+        
+      clusters:
+      
+      {{- if .Values.parent.enabled }}
+      # If child layer point to parent proxy entrypoint
+      - name: parent-passthrough
+        type: LOGICAL_DNS
+        dns_lookup_family: V4_ONLY
+        load_assignment:
+          cluster_name: parent-passthrough
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ .Values.parent.proxyIp }}
+                    port_value: {{ .Values.parent.proxyHttpsPort }}
+                    
+      - name: parent-passthrough-obo
+        type: LOGICAL_DNS
+        dns_lookup_family: V4_ONLY
+        load_assignment:
+          cluster_name: parent-passthrough-obo
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ .Values.parent.proxyIp }}
+                    port_value: {{ .Values.parent.proxyOboPort }}
+      {{- else }}
+      # else if this is top layer point to outbound public URIs
+      {{- $httpsPort := .Values.parent.proxyHttpsPort -}}
+      {{- range $key, $val := .Values.arcDomainNames }}
+      - name: {{ $key }}
+        type: LOGICAL_DNS
+        dns_lookup_family: V4_ONLY
+        load_assignment:
+          cluster_name: {{ $key }}
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ $val }}
+                    port_value: {{ $httpsPort }}
+      {{- end }}
+      {{- range $key, $val := .Values.arcRegionalDomains }}
+      - name: {{ $key }}
+        type: LOGICAL_DNS
+        dns_lookup_family: V4_ONLY
+        load_assignment:
+          cluster_name: {{ $key }}
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ $domainRegion -}} {{ $val }}
+                    port_value: {{ $httpsPort }}
+      {{- end }}
+      {{- range $key, $val := .Values.customDomains }}
+      - name: {{ $key }}
+        type: LOGICAL_DNS
+        dns_lookup_family: V4_ONLY
+        load_assignment:
+          cluster_name: {{ $key }}
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ $val }}
+                    port_value: {{ $httpsPort }}
+      {{- end }}
+      {{- if .Values.arcWildcardSubDomains}}
+      - name: dynamic_forward_proxy_cluster
+        lb_policy: CLUSTER_PROVIDED
+        cluster_type:
+          name: envoy.clusters.dynamic_forward_proxy
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+            dns_cache_config:
+              name: dynamic_forward_proxy_cache_config
+              dns_lookup_family: V4_ONLY
+      
+      {{- end }}
+
+      {{- $oboPort := .Values.parent.proxyOboPort -}}
+      {{- if .Values.arcOboClusterConnect }}
+      - name: region-obo-arc-azure-com
+        type: LOGICAL_DNS
+        dns_lookup_family: V4_ONLY
+        load_assignment:
+          cluster_name: region-obo-arc-azure-com
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ $domainRegion -}} {{ .Values.arcOboClusterConnect.region_obo_arc_azure_com }}
+                    port_value: {{ $oboPort }}
+      
+      {{- end }}
+
+
+      {{- end }}
+
+    layered_runtime:
+      layers:
+      - name: static_layer_0
+        static_layer:
+          overload:
+            global_downstream_max_connections: 50000

--- a/deployment/helm/envoy/templates/envoy/service.yaml
+++ b/deployment/helm/envoy/templates/envoy/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-service
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    app: envoy-module
+  ports:
+    - protocol: TCP
+      name: https
+      port: {{ .Values.envoyReverseProxy.httpsPort }}
+      targetPort: {{ .Values.envoyReverseProxy.httpsContainerPort }}
+    - protocol: TCP
+      name: obo
+      port: {{ .Values.envoyReverseProxy.oboPort }}
+      targetPort: {{ .Values.envoyReverseProxy.oboPort }}

--- a/deployment/helm/envoy/values.yaml
+++ b/deployment/helm/envoy/values.yaml
@@ -1,0 +1,70 @@
+# envoy proxy settings
+envoyReverseProxy:
+  httpsContainerPort: 50000
+  httpsPort: 443
+  oboPort: 8084
+
+command:
+  - /usr/local/bin/envoy
+
+args:
+  - -c
+  - /etc/envoy/envoy.yaml
+  - -l
+  - debug
+
+parent:
+  enabled: false
+  proxyIp: to_replace
+  proxyHttpsPort: 443
+  proxyOboPort: 8084
+
+domainRegion: northeurope
+
+arcDomainNames:
+  management_azure_com: management.azure.com
+  management_core_windows_net: management.core.windows.net
+  login_windows_net: login.windows.net
+  mcr_microsoft_com: mcr.microsoft.com
+  guestnotificationservice_azure_com: guestnotificationservice.azure.com
+  login_microsoftonline_com: login.microsoftonline.com
+  k8connecthelm_azureedge_net: k8connecthelm.azureedge.net
+  sts_windows_net: sts.windows.net
+  k8sconnectcsp_azureedge_net: k8sconnectcsp.azureedge.net
+  graph_microsoft_com: graph.microsoft.com
+  azurepolicyarckubernetes_azurecr_io: azurepolicyarckubernetes.azurecr.io # not documented
+  graph_windows_net: graph.windows.net # from arc 'server' requirements
+  manifestcdndev_azureedge_net: manifestcdndev.azureedge.net # not documented
+  data_policy_core_windows_net: data.policy.core.windows.net # not documented
+  gbl_his_arc_azure_com: gbl.his.arc.azure.com
+  package_ms_com: packages.microsoft.com # for AKS egress
+  acs_mirror_azureedge_net: acs-mirror.azureedge.net # for AKS egress
+
+  # dc_services_visualstudio_com: dc.services.visualstudio.com # from arc server requirements
+  # aka_ms: aka.ms # from arc 'server' requirements
+  # pas_windows_net: pas.windows.net # from arc 'server'requirements
+
+arcRegionalDomains:
+  region_dp_kubernetesconfg_azure_com: .dp.kubernetesconfiguration.azure.com
+  region_rp_kubernetesconfg_azure_com: .rp.kubernetesconfiguration.azure.com
+  region_login_microsoft_com: .login.microsoft.com
+  region_monitoring_azure_com: .monitoring.azure.com # from other docs
+  region_obo_arc_azure_com: .obo.arc.azure.com # https://<region>.obo.arc.azure.com:8084/ for cluster connect
+
+arcWildcardSubDomains:
+  his_arc_azure_com: "*.his.arc.azure.com"
+  arc_azure_net: "*.arc.azure.net"
+  data_mcr_microsoft_com: "*.data.mcr.microsoft.com"
+  guestnotificationservice_azure_com: "*.guestnotificationservice.azure.com"
+  hcp_region_azmk8s.io: "*.azmk8s.io" # for AKS egress
+  docker_com: "*.docker.com" # temporary for mosquitto image # TODO remove once usage of connected container registry
+  docker_io: "*.docker.io" # temporary for mosquitto image # TODO remove once usage of connected container registry
+  azurecr_io: "*.azurecr.io" # temporary for dev images of this project # TODO remove once usage of connected container registry
+  githubusercontent_com: "*.githubusercontent.com" # temporary for dev images of this project # TODO remove once usage of connected container registry
+
+arcOboClusterConnect:
+  region_obo_arc_azure_com: ".obo.arc.azure.com" # https://<region>.obo.arc.azure.com:8084/ for cluster connect
+
+# Provide additional domains that you want to proxy through, pass the whole collection through Values
+# customDomains:
+#   domain1: www.domain1.com


### PR DESCRIPTION
- New GH Actions releases for two new Helm charts
- New Helm chart for Envoy proxy deployment for using as reverse proxy
- New DNSMasqAsk chart for hosting a custom DNS resolver for child cluster and point to Envoy (for AKS host)